### PR TITLE
Add signed agent release workflow and relay installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,141 @@
+name: Android release
+
+on:
+  push:
+    tags:
+      - "agent-v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: android-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-release:
+    name: Signed rewrite APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      ANDROID_IMAGE: rishmcp-android-release
+      BUILD_TOOLS: /opt/android-sdk/build-tools/35.0.0
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate release tag and source version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="$GITHUB_REF_NAME"
+          version="${tag#agent-v}"
+          if ! printf '%s' "$version" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo "::error::release tag must be agent-vMAJOR.MINOR.PATCH: $tag"
+            exit 1
+          fi
+          source_version="$(sed -nE 's/^[[:space:]]*versionName = "([^"]+)"/\1/p' app/app/build.gradle.kts | head -n 1)"
+          if [ "$source_version" != "$version" ]; then
+            echo "::error::tag $tag does not match app versionName $source_version"
+            exit 1
+          fi
+          echo "RELEASE_TAG=$tag" >> "$GITHUB_ENV"
+          echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Restore and validate official signing keystore
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for name in ANDROID_KEYSTORE_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Missing required repository secret: $name"
+              exit 1
+            fi
+          done
+          umask 077
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > app/release.keystore
+          keytool -list \
+            -keystore app/release.keystore \
+            -storepass "$ANDROID_KEYSTORE_PASSWORD" \
+            -alias "$ANDROID_KEY_ALIAS" >/dev/null
+
+      - name: Build Android toolchain image
+        run: docker build --file app/Dockerfile.build --tag "$ANDROID_IMAGE" app
+
+      - name: Run Android tests and assemble unsigned release APK
+        run: >-
+          docker run --rm
+          --volume "${GITHUB_WORKSPACE}/app:/work"
+          --workdir /work
+          "$ANDROID_IMAGE"
+          gradle --no-daemon testDebugUnitTest assembleRelease
+
+      - name: Sign and verify release APK
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --volume "${GITHUB_WORKSPACE}/app:/work" \
+            --workdir /work \
+            --env ANDROID_KEYSTORE_PASSWORD \
+            --env ANDROID_KEY_ALIAS \
+            --env ANDROID_KEY_PASSWORD \
+            --env BUILD_TOOLS \
+            --env RELEASE_VERSION \
+            "$ANDROID_IMAGE" \
+            bash -euc '
+              unsigned=/work/app/build/outputs/apk/release/app-release-unsigned.apk
+              signed=/work/rish-mcp-agent-${RELEASE_VERSION}.apk
+              test -f "$unsigned"
+              "$BUILD_TOOLS/apksigner" sign \
+                --ks /work/release.keystore \
+                --ks-key-alias "$ANDROID_KEY_ALIAS" \
+                --ks-pass env:ANDROID_KEYSTORE_PASSWORD \
+                --key-pass env:ANDROID_KEY_PASSWORD \
+                --out "$signed" \
+                "$unsigned"
+              "$BUILD_TOOLS/apksigner" verify --verbose --print-certs "$signed"
+              badging="$("$BUILD_TOOLS/aapt" dump badging "$signed")"
+              printf '%s\n' "$badging" | grep -F "package: name='kr.scin.rishmcp' "
+              printf '%s\n' "$badging" | grep -F "versionName='${RELEASE_VERSION}'"
+            '
+
+      - name: Create checksum and enforce asset limit
+        shell: bash
+        run: |
+          set -euo pipefail
+          apk="app/rish-mcp-agent-${RELEASE_VERSION}.apk"
+          test -f "$apk"
+          sha256sum "$apk" | tee "$apk.sha256"
+          size="$(stat -c '%s' "$apk")"
+          if [ "$size" -gt 134217728 ]; then
+            echo "::error::APK exceeds the 128 MiB public-server limit: $size bytes"
+            exit 1
+          fi
+          ls -lh "$apk" "$apk.sha256"
+
+      - name: Publish signed preview release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$RELEASE_TAG" \
+            "app/rish-mcp-agent-${RELEASE_VERSION}.apk#rish-mcp agent ${RELEASE_VERSION} APK" \
+            "app/rish-mcp-agent-${RELEASE_VERSION}.apk.sha256#SHA-256 checksum" \
+            --verify-tag \
+            --prerelease \
+            --title "rish-mcp agent ${RELEASE_VERSION} (preview)" \
+            --notes "Signed rewrite APK built from ${GITHUB_SHA}. This is a preview release: real-device pairing, relay/list_devices/run_shell validation, and upgrade validation remain required before stable publication."
+
+      - name: Remove signing material
+        if: ${{ always() }}
+        run: rm -f app/release.keystore

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -91,7 +91,25 @@ the `websecure` entrypoint and the `letsencrypt` certificate resolver used by
 the labels in the Compose file. The Android WebSocket upgrade is handled by
 Traefik automatically.
 
-### 2.4 Run one container manually
+### 2.4 One-command relay installer
+
+The project landing page exposes a small installer for the self-hosted relay:
+
+```bash
+curl -fsSL https://rish-mcp.turin.my/relay | sh
+```
+
+It pulls `ghcr.io/turin-dev/rish-mcp-relay:latest`, creates random
+`AI_TOKEN`/`DEVICE_TOKEN` values when none are supplied, stores them in
+`~/.config/rish-mcp/relay.env` with mode `600`, and replaces only the named
+`rish-mcp-relay` container. The script publishes the container on host port
+`8080` by default; set `RISH_MCP_RELAY_PORT` or
+`RISH_MCP_RELAY_CONFIG_DIR` before running it to change those defaults. Put a
+TLS reverse proxy in front of that port before using the relay from an AI
+client or Android phone. The installer does not create DNS records or TLS
+certificates.
+
+### 2.5 Run one container manually
 
 For local testing without Traefik, run the relay directly:
 
@@ -105,7 +123,7 @@ docker run --rm -p 8080:8080 \
 For production, put a TLS reverse proxy in front of the container (nginx,
 Caddy, or Traefik) and forward WebSocket upgrades on `/agent`.
 
-### 2.5 Verify
+### 2.6 Verify
 
 ```bash
 curl -s https://mcp.example.com/healthz

--- a/web/app/relay/route.ts
+++ b/web/app/relay/route.ts
@@ -1,0 +1,96 @@
+export const dynamic = "force-static";
+
+const INSTALLER = `#!/usr/bin/env sh
+set -eu
+
+IMAGE="\${RISH_MCP_RELAY_IMAGE:-ghcr.io/turin-dev/rish-mcp-relay:latest}"
+CONTAINER_NAME="\${RISH_MCP_RELAY_NAME:-rish-mcp-relay}"
+PORT="\${RISH_MCP_RELAY_PORT:-8080}"
+CONFIG_DIR="\${RISH_MCP_RELAY_CONFIG_DIR:-\${XDG_CONFIG_HOME:-$HOME/.config}/rish-mcp}"
+ENV_FILE="$CONFIG_DIR/relay.env"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required. Install Docker Desktop or Docker Engine and run this again." >&2
+  exit 1
+fi
+
+case "$PORT" in
+  ''|*[!0-9]*)
+    echo "RISH_MCP_RELAY_PORT must be a numeric host port." >&2
+    exit 1
+    ;;
+esac
+
+new_token() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 24
+  elif [ -r /dev/urandom ] && command -v od >/dev/null 2>&1; then
+    od -An -N24 -tx1 /dev/urandom | tr -d ' \\n'
+  else
+    echo "openssl or /dev/urandom is required to create relay credentials." >&2
+    exit 1
+  fi
+}
+
+umask 077
+mkdir -p "$CONFIG_DIR"
+
+if [ ! -s "$ENV_FILE" ]; then
+  ai_token="\${AI_TOKEN:-$(new_token)}"
+  device_token="\${DEVICE_TOKEN:-$(new_token)}"
+  {
+    printf 'AI_TOKEN=%s\\n' "$ai_token"
+    printf 'DEVICE_TOKEN=%s\\n' "$device_token"
+  } > "$ENV_FILE"
+fi
+chmod 600 "$ENV_FILE"
+
+if ! sed -n 's/^AI_TOKEN=//p' "$ENV_FILE" | head -n 1 | grep -q '[^[:space:]]'; then
+  echo "relay.env has no non-empty AI_TOKEN: $ENV_FILE" >&2
+  exit 1
+fi
+if ! sed -n 's/^DEVICE_TOKEN=//p' "$ENV_FILE" | head -n 1 | grep -q '[^[:space:]]'; then
+  echo "relay.env has no non-empty DEVICE_TOKEN: $ENV_FILE" >&2
+  exit 1
+fi
+
+echo "Pulling $IMAGE..."
+docker pull "$IMAGE"
+
+# Replace only the named container created by this installer so re-running the
+# command upgrades the relay without touching unrelated Docker workloads.
+if docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+  docker rm -f "$CONTAINER_NAME" >/dev/null
+fi
+
+docker run --detach \\
+  --name "$CONTAINER_NAME" \\
+  --restart unless-stopped \\
+  --publish "$PORT:8080" \\
+  --env-file "$ENV_FILE" \\
+  --env PORT=8080 \\
+  --read-only \\
+  --tmpfs /tmp:size=64m,noexec,nosuid,nodev \\
+  --cap-drop ALL \\
+  --security-opt no-new-privileges:true \\
+  --log-opt max-size=10m \\
+  --log-opt max-file=3 \\
+  "$IMAGE"
+
+printf '\\nRelay container: %s\\n' "$CONTAINER_NAME"
+printf 'Local health check: http://127.0.0.1:%s/healthz\\n' "$PORT"
+printf 'MCP endpoint (place behind HTTPS): /mcp\\n'
+printf 'Android WebSocket (place behind HTTPS): /agent\\n'
+printf 'Credentials saved with mode 600: %s\\n' "$ENV_FILE"
+`;
+
+export function GET() {
+  return new Response(INSTALLER, {
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Disposition": 'inline; filename="install-relay.sh"',
+      "Content-Type": "text/plain; charset=utf-8",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add a tag-driven Android release workflow using the existing repository signing secrets
- build/test the release variant, sign it with the official keystore, verify the APK identity/signature, checksum it, and publish a signed preview release
- add `GET /relay` to the web app as a self-hosted Docker relay installer
- document `curl -fsSL https://rish-mcp.turin.my/relay | sh`

## Verification
- `web`: `npm run lint`
- `web`: `npm run build`
- Android Docker toolchain: `gradle --no-daemon testDebugUnitTest assembleRelease`
- local temporary-key `apksigner verify` and manifest identity check
- local `/relay` response returned 200 and passed `bash -n`

## Release boundary
The tag workflow publishes a GitHub **preview** release. Real-device pairing, relay/list_devices/run_shell validation, and upgrade validation remain required before a stable release.