### PR TITLE
Make release APK metadata check shell-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,11 @@ jobs:
                 "$unsigned"
               "$BUILD_TOOLS/apksigner" verify --verbose --print-certs "$signed"
               badging="$("$BUILD_TOOLS/aapt" dump badging "$signed")"
-              package_line="$(printf '%s\n' "$badging" | grep -E "^package: name=")"
+              package_line="$(printf "%s\n" "$badging" | grep -E "^package: name=")"
               version_pattern="${RELEASE_VERSION//./\\.}"
-              printf '%s\n' "$package_line" | grep -Eq "^package: name='kr\\.scin\\.rishmcp' versionCode='[0-9]+' versionName='${version_pattern}'( |$)"
+              quote="$(printf "\\047")"
+              package_pattern="^package: name=${quote}kr\\.scin\\.rishmcp${quote} versionCode=${quote}[0-9]+${quote} versionName=${quote}${version_pattern}${quote}( |$)"
+              printf "%s\n" "$package_line" | grep -Eq "$package_pattern"
             '
 
       - name: Create checksum and enforce asset limit


### PR DESCRIPTION
## Summary
- keep the exact package/version metadata gate safe inside the nested release container shell
- build the regex quote character with `printf "\\047"` so outer shell quoting cannot terminate early
- retain exact field-boundary checks for the package name and tag version

## Verification
- local matcher accepts the expected `aapt` line
- local matcher rejects package suffixes, version prefixes, and version suffixes
- `git diff --check` passes

This fixes the release run failure after unsigned APK assembly on `agent-v0.1.0`; the official signing step itself had already succeeded in the prior run.